### PR TITLE
feat: --save-images [directory=output_images]

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Here are the most important options:
 
 - `--source`: Path to your image, video, or webcam index (default is `0` for webcam).
 - `--save`: Save path for the output.
+- `--save-images`: Save the card images and photos of detected cards.
 - `--show`: Display the output in a window.
 - `--display-card`: Display detected cards on the output.
 - `--deck-list`: Path to a ydk file containing the list of cards in your deck for better recognition.

--- a/README_fr.md
+++ b/README_fr.md
@@ -86,6 +86,7 @@ python -m draw --help
 Les options les plus importantes sont les suivantes :
 - `--source`: Chemin vers l'image, la vidéo ou l'indice de la webcam (par default, `0` pour la webcam).
 - `--save`: Chemin où sauvegarder la vidéo.
+- `--save-images`: Pour sauvegarder les images et les photos des cartes détectées.
 - `--show`: Pour afficher la vidéo en temps réel.
 - `--display-card`: Pour afficher l'image de la carte détectée.
 - `--deck-list`: Chemin vers un fichier ydk contenant la deck lists (permet d'améliorer la précision).

--- a/src/draw/__main__.py
+++ b/src/draw/__main__.py
@@ -5,7 +5,7 @@ import time
 import urllib
 from functools import wraps
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Any
 
 import cv2
 import numpy as np
@@ -13,6 +13,9 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
 from draw.draw import Draw
+
+
+OpenCVImage = cv2.Mat | np.ndarray[Any, np.dtype]
 
 
 def parse_command_line():
@@ -53,7 +56,7 @@ def save(is_image, outputs, video_writer, save_path):
         video_writer.write(outputs['image'])
 
 
-def detect_card(outputs, counts, displayed, dataset, label2id, on_detected: Callable[[any, any, any], None]):
+def detect_card(outputs, counts, displayed, dataset, label2id, on_detected: Callable[[OpenCVImage, OpenCVImage, str], None]):
     for label in outputs['predictions']:
         if label not in counts:
             counts[label] = 0


### PR DESCRIPTION
the option saves photos and card images to `output_images/` or the user defined dir

it avoids saving duplicates, but has the trade-off of not saving actual consecutive cards the user scan if they were to be a copy of one another

Manual Test
```
python -m draw --show --display-card --save-images
```