### PR TITLE
Enhance run.py with Windows shared memory and logging improvements

### DIFF
--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -1,8 +1,12 @@
 import ctypes
 import struct
+import sys
 import time
 from collections import deque
 from multiprocessing import shared_memory
+
+if sys.platform == 'win32':
+    import mmap
 
 from draw.draw import Draw
 from draw.utils import read_shared_frame, get_deck_list
@@ -15,6 +19,8 @@ OBS_SHM_NAME = "obs_shared_memory"
 PYTHON_SHM_NAME = "python_shared_memory"
 HEADER_FORMAT = "II"
 HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+
+SIZE = 8104 * 1024
 
 
 class DrawSharedMemoryHandler:
@@ -45,10 +51,15 @@ class DrawSharedMemoryHandler:
         while continue_execution:
             continue_execution = True if address is None else address.contents.value
             try:
-                self.obs_shm = shared_memory.SharedMemory(name=OBS_SHM_NAME)
+                if sys.platform == 'win32':
+                    self.obs_shm = mmap.mmap(-1, SIZE, tagname=OBS_SHM_NAME, access=mmap.ACCESS_READ)
+                else:
+                    self.obs_shm = shared_memory.SharedMemory(name=OBS_SHM_NAME)
             except FileNotFoundError:
                 continue
             except ValueError:
+                continue
+            except OSError:
                 continue
             except KeyboardInterrupt:
                 return
@@ -58,11 +69,24 @@ class DrawSharedMemoryHandler:
         while continue_execution:
             try:
                 continue_execution = True if address is None else address.contents.value
-                image = read_shared_frame(self.obs_shm.buf, HEADER_SIZE, HEADER_FORMAT)
-            except TypeError:
-                breakpoint()
-            except ValueError:
-                breakpoint()
+                if sys.platform == 'win32':
+                    self.obs_shm.seek(0)
+                    buf = self.obs_shm.read(SIZE)  # self.obs_shm.size())
+                else:
+                    buf = self.obs_shm.buf
+                image = read_shared_frame(buf, HEADER_SIZE, HEADER_FORMAT)
+            except TypeError as e:
+                print("Type Error: ", e)
+                print("Stopping Draw2...")
+                self.obs_shm.close()
+                self.python_shm.close()
+                return
+            except ValueError as e:
+                print("Value Error: ", e)
+                print("Stopping Draw2...")
+                self.obs_shm.close()
+                self.python_shm.close()
+                return
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
                 self.obs_shm.close()
@@ -130,15 +154,30 @@ class DrawSharedMemoryHandler:
         total_size = HEADER_SIZE + len(img_bytes)
 
         if self.python_shm is None:
-            self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
+            if sys.platform == 'win32':
+                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+                self.python_shm.seek(0)
+                self.python_shm.write(b"\x00" * total_size)
+            else:
+                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
 
         if total_size != self.python_shm.size:
             self.python_shm.close()
-            self.python_shm.unlink()
-            self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
+            if sys.platform == 'win32':
+                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+                self.python_shm.seek(0)
+                self.python_shm.write(b"\x00" * total_size)
+            else:
+                self.python_shm.unlink()
+                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
 
-        self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
-        self.python_shm.buf[HEADER_SIZE:] = img_bytes
+        if sys.platform == 'win32':
+            self.python_shm.seek(0)
+            self.python_shm.write(struct.pack(HEADER_FORMAT, width, height))
+            self.python_shm.write(img_bytes)
+        else:
+            self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
+            self.python_shm.buf[HEADER_SIZE:] = img_bytes
 
         print(f"Sent image {width}x{height} to OBS")
 

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -12,7 +12,26 @@ import os
 import sys
 import logging
 
-logging.disable(logging.CRITICAL)
+log_dir = os.path.join(os.environ["APPDATA"], "obs-studio")
+os.makedirs(log_dir, exist_ok=True)
+
+log_path = os.path.join(log_dir, "python_subprocess.log")
+
+# --- logging (flushes immediately) ---
+logging.basicConfig(
+    filename=log_path,
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    force=True,   # important if logging was configured before
+)
+
+# --- redirect print() too ---
+log_file = open(log_path, "a", buffering=1)  # line-buffered
+sys.stdout = log_file
+sys.stderr = log_file
+
+logging.info("Python subprocess started")
+print("print() is real-time now")
 
 OBS_SHM_NAME = "obs_shared_memory"
 PYTHON_SHM_NAME = "python_shared_memory"

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -61,18 +61,17 @@ class DrawSharedMemoryHandler:
                 else:
                     self.obs_shm = shared_memory.SharedMemory(name=OBS_SHM_NAME)
                     print("mapped size:", self.obs_shm.size)
-            except FileNotFoundError:
-                continue
-            except ValueError:
-                continue
-            except OSError:
+            except (FileNotFoundError, ValueError, OSError):
                 continue
             except KeyboardInterrupt:
                 return
             break
 
         print(f"Shared memory found")
-        buf = memoryview(self.obs_shm)
+        if sys.platform == 'win32':
+            buf = memoryview(self.obs_shm)
+        else:
+            buf = memoryview(self.obs_shm.buf)
         while continue_execution:
             try:
                 continue_execution = True if address is None else address.contents.value
@@ -144,31 +143,25 @@ class DrawSharedMemoryHandler:
 
     def send_image_to_obs(self, image):
         img_array = np.array(image.convert("RGBA"))
-        width, height = img_array.shape
+        print(image.size)
+        width, height, channels = img_array.shape
 
         total_size = HEADER_SIZE + img_array.nbytes
 
-        if self.python_shm is None:
-            if sys.platform == 'win32':
-                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-                self.python_shm.seek(0)
-                self.python_shm.write(b"\x00" * total_size)
-            else:
-                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
-
-        if sys.platform == 'win32' and total_size != self.python_shm.size():
+        if sys.platform == 'win32' and (self.python_shm is None or total_size != self.python_shm.size()):
+            if self.python_shm is not None:
                 self.python_shm.close()
-                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-                self.python_shm.seek(0)
-                self.python_shm.write(b"\x00" * total_size)
-                self.shm_array = np.ndarray((height, width, 4), dtype=np.uint8, buffer=self.buf)
-        elif total_size != self.python_shm.size:
+            self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+            self.python_shm.seek(0)
+            self.python_shm.write(b"\x00" * total_size)
+            self.shm_array = np.ndarray((width, height, channels), dtype=np.uint8, buffer=self.buf[HEADER_SIZE:])
+        elif self.python_shm is None or total_size != self.python_shm.size:
+            if self.python_shm is not None:
                 self.python_shm.close()
                 self.python_shm.unlink()
-                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
-                self.shm_array = np.ndarray((height, width, 4), dtype=np.uint8, buffer=self.buf)
-
-
+            self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
+            self.shm_array = np.ndarray((width, height, channels), dtype=np.uint8, buffer=self.python_shm.buf[HEADER_SIZE:])
+            self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, height, width)
         self.shm_array[:] = img_array
 
         print(f"Sent image {width}x{height} to OBS")

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -68,13 +68,13 @@ class DrawSharedMemoryHandler:
 
         print(f"Shared memory found")
         if sys.platform == 'win32':
-            buf = memoryview(self.obs_shm)
+            obs_buf = memoryview(self.obs_shm)
         else:
-            buf = memoryview(self.obs_shm.buf)
+            obs_buf = memoryview(self.obs_shm.buf)
         while continue_execution:
             try:
                 continue_execution = True if address is None else address.contents.value
-                image = read_shared_frame(buf, HEADER_SIZE, HEADER_FORMAT)
+                image = read_shared_frame(obs_buf, HEADER_SIZE, HEADER_FORMAT)
             except TypeError as e:
                 print("type error: ", e)
                 break
@@ -153,7 +153,9 @@ class DrawSharedMemoryHandler:
             self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
             self.python_shm.seek(0)
             self.python_shm.write(b"\x00" * total_size)
-            self.shm_array = np.ndarray((height, width, channels), dtype=np.uint8, buffer=memoryview(self.python_shm)[HEADER_SIZE:])
+            python_buf = memoryview(self.python_shm)
+            self.shm_array = np.ndarray((height, width, channels), dtype=np.uint8, buffer=python_buf[HEADER_SIZE:])
+            python_buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
         elif self.python_shm is None or total_size != self.python_shm.size:
             if self.python_shm is not None:
                 self.python_shm.close()

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -5,6 +5,7 @@ from collections import deque
 from multiprocessing import shared_memory
 import mmap
 
+import numpy as np
 from draw.draw import Draw
 from draw.utils import read_shared_frame, get_deck_list
 
@@ -12,33 +13,17 @@ import os
 import sys
 import logging
 
-log_dir = os.path.join(os.environ["APPDATA"], "obs-studio")
-os.makedirs(log_dir, exist_ok=True)
-
-log_path = os.path.join(log_dir, "python_subprocess.log")
-
-# --- logging (flushes immediately) ---
-logging.basicConfig(
-    filename=log_path,
-    level=logging.DEBUG,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    force=True,   # important if logging was configured before
-)
-
-# --- redirect print() too ---
-log_file = open(log_path, "a", buffering=1)  # line-buffered
-sys.stdout = log_file
-sys.stderr = log_file
-
-logging.info("Python subprocess started")
-print("print() is real-time now")
-
 OBS_SHM_NAME = "obs_shared_memory"
 PYTHON_SHM_NAME = "python_shared_memory"
 HEADER_FORMAT = "II"
 HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
 
-SIZE = 8104 * 1024
+MAX_FRAME_WIDTH = 3840
+MAX_FRAME_HEIGHT = 2160
+BYTES_PER_PIXEL = 4  # RGBA8
+FRAME_BUFFER_SIZE = MAX_FRAME_WIDTH * MAX_FRAME_HEIGHT * BYTES_PER_PIXEL
+
+SIZE = HEADER_SIZE + FRAME_BUFFER_SIZE
 
 
 class DrawSharedMemoryHandler:
@@ -48,6 +33,7 @@ class DrawSharedMemoryHandler:
         self.obs_shm = None
         self.python_shm = None
         self.buf = None
+        self.shm_array = None
 
         self.minimum_out_of_screen_time = minimum_out_of_screen_time
         self.minimum_screen_time = minimum_screen_time
@@ -69,8 +55,12 @@ class DrawSharedMemoryHandler:
         while continue_execution:
             continue_execution = True if address is None else address.contents.value
             try:
-                self.obs_shm = mmap.mmap(-1, SIZE, tagname=OBS_SHM_NAME, access=mmap.ACCESS_READ)
-                print("mapped size:", self.obs_shm.size())
+                if sys.platform == 'win32':
+                    self.obs_shm = mmap.mmap(-1, SIZE, tagname=OBS_SHM_NAME, access=mmap.ACCESS_READ)
+                    print("mapped size:", self.obs_shm.size())
+                else:
+                    self.obs_shm = shared_memory.SharedMemory(name=OBS_SHM_NAME)
+                    print("mapped size:", self.obs_shm.size)
             except FileNotFoundError:
                 continue
             except ValueError:
@@ -82,22 +72,22 @@ class DrawSharedMemoryHandler:
             break
 
         print(f"Shared memory found")
+        buf = memoryview(self.obs_shm)
         while continue_execution:
             try:
                 continue_execution = True if address is None else address.contents.value
-                self.obs_shm.seek(0)
-                buf = self.obs_shm.read(SIZE) #self.obs_shm.size())
                 image = read_shared_frame(buf, HEADER_SIZE, HEADER_FORMAT)
             except TypeError as e:
                 print("type error: ", e)
-                breakpoint()
+                break
             except ValueError as e:
                 print("value error: ", e)
-                breakpoint()
+                break
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
                 self.obs_shm.close()
                 self.python_shm.close()
+                log_file.close()
                 return
 
             if image.size[0] == 0 or image.size[1] == 0:
@@ -115,13 +105,12 @@ class DrawSharedMemoryHandler:
                 for result in results:
                     outputs = self.draw.process(result)
                     self.display_card(outputs)
-            # except Exception as e:
-            #     print(f"Error processing shared memory: {e}")
-            #     breakpoint()
+
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
                 self.obs_shm.close()
                 self.python_shm.close()
+                log_file.close()
                 return
 
     def display_card(self, outputs):
@@ -154,26 +143,33 @@ class DrawSharedMemoryHandler:
                         self.counts[label] = 0
 
     def send_image_to_obs(self, image):
-        img_rgba = image.convert("RGBA")
-        width, height = img_rgba.size
-        img_bytes = img_rgba.tobytes()
+        img_array = np.array(image.convert("RGBA"))
+        width, height = img_array.shape
 
-        total_size = HEADER_SIZE + len(img_bytes)
+        total_size = HEADER_SIZE + img_array.nbytes
 
         if self.python_shm is None:
-            self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-            self.python_shm.seek(0)
-            self.python_shm.write(b"\x00" * total_size)
+            if sys.platform == 'win32':
+                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+                self.python_shm.seek(0)
+                self.python_shm.write(b"\x00" * total_size)
+            else:
+                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
 
-        if total_size != self.python_shm.size:
-            self.python_shm.close()
-            self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-            self.python_shm.seek(0)
-            self.python_shm.write(b"\x00" * total_size)
+        if sys.platform == 'win32' and total_size != self.python_shm.size():
+                self.python_shm.close()
+                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+                self.python_shm.seek(0)
+                self.python_shm.write(b"\x00" * total_size)
+                self.shm_array = np.ndarray((height, width, 4), dtype=np.uint8, buffer=self.buf)
+        elif total_size != self.python_shm.size:
+                self.python_shm.close()
+                self.python_shm.unlink()
+                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
+                self.shm_array = np.ndarray((height, width, 4), dtype=np.uint8, buffer=self.buf)
 
-        self.python_shm.seek(0)
-        self.python_shm.write(struct.pack(HEADER_FORMAT, width, height))
-        self.python_shm.write(img_bytes)
+
+        self.shm_array[:] = img_array
 
         print(f"Sent image {width}x{height} to OBS")
 
@@ -211,5 +207,27 @@ def run(
 
 
 if __name__ == '__main__':
+    if sys.platform == 'win32':
+        log_dir = os.path.join(os.environ["APPDATA"], "obs-studio")
+        os.makedirs(log_dir, exist_ok=True)
+
+        log_path = os.path.join(log_dir, "python_subprocess.log")
+
+        # --- logging (flushes immediately) ---
+        logging.basicConfig(
+            filename=log_path,
+            level=logging.DEBUG,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+            force=True,  # important if logging was configured before
+        )
+
+        # --- redirect print() too ---
+        log_file = open(log_path, "a", buffering=1)  # line-buffered
+        sys.stdout = log_file
+        sys.stderr = log_file
+
+        logging.info("Python subprocess started")
+        print("print() is real-time now")
+
     print("run")
     run()

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -32,7 +32,6 @@ class DrawSharedMemoryHandler:
 
         self.obs_shm = None
         self.python_shm = None
-        self.buf = None
         self.shm_array = None
 
         self.minimum_out_of_screen_time = minimum_out_of_screen_time
@@ -84,8 +83,8 @@ class DrawSharedMemoryHandler:
                 break
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
-                self.obs_shm.close()
-                self.python_shm.close()
+                close_shared_memory(self.obs_shm)
+                close_shared_memory(self.python_shm)
                 log_file.close()
                 return
 
@@ -107,8 +106,8 @@ class DrawSharedMemoryHandler:
 
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
-                self.obs_shm.close()
-                self.python_shm.close()
+                close_shared_memory(self.obs_shm)
+                close_shared_memory(self.python_shm)
                 log_file.close()
                 return
 
@@ -144,7 +143,7 @@ class DrawSharedMemoryHandler:
     def send_image_to_obs(self, image):
         img_array = np.array(image.convert("RGBA"))
         print(image.size)
-        width, height, channels = img_array.shape
+        height, width, channels = img_array.shape
 
         total_size = HEADER_SIZE + img_array.nbytes
 
@@ -154,18 +153,26 @@ class DrawSharedMemoryHandler:
             self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
             self.python_shm.seek(0)
             self.python_shm.write(b"\x00" * total_size)
-            self.shm_array = np.ndarray((width, height, channels), dtype=np.uint8, buffer=self.buf[HEADER_SIZE:])
+            self.shm_array = np.ndarray((height, width, channels), dtype=np.uint8, buffer=memoryview(self.python_shm)[HEADER_SIZE:])
         elif self.python_shm is None or total_size != self.python_shm.size:
             if self.python_shm is not None:
                 self.python_shm.close()
                 self.python_shm.unlink()
             self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
-            self.shm_array = np.ndarray((width, height, channels), dtype=np.uint8, buffer=self.python_shm.buf[HEADER_SIZE:])
-            self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, height, width)
+            self.shm_array = np.ndarray((height, width, channels), dtype=np.uint8, buffer=self.python_shm.buf[HEADER_SIZE:])
+            self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
         self.shm_array[:] = img_array
 
         print(f"Sent image {width}x{height} to OBS")
 
+def close_shared_memory(shm):
+    if sys.platform == 'win32':
+        if shm is not None:
+            shm.close()
+    else:
+        if shm is not None:
+            shm.close()
+            shm.unlink()
 
 def run(
         stop_flag=None,
@@ -193,10 +200,8 @@ def run(
         print("Running Draw2 without OBS shared memory")
         sh_memory_handler()
 
-    if sh_memory_handler.obs_shm is not None:
-        sh_memory_handler.obs_shm.unlink()
-    if sh_memory_handler.python_shm is not None:
-        sh_memory_handler.python_shm.unlink()
+    close_shared_memory(sh_memory_handler.obs_shm)
+    close_shared_memory(sh_memory_handler.python_shm)
 
 
 if __name__ == '__main__':

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -1,16 +1,15 @@
 import ctypes
 import struct
-import sys
 import time
 from collections import deque
 from multiprocessing import shared_memory
-
-if sys.platform == 'win32':
-    import mmap
+import mmap
 
 from draw.draw import Draw
 from draw.utils import read_shared_frame, get_deck_list
 
+import os
+import sys
 import logging
 
 logging.disable(logging.CRITICAL)
@@ -51,10 +50,8 @@ class DrawSharedMemoryHandler:
         while continue_execution:
             continue_execution = True if address is None else address.contents.value
             try:
-                if sys.platform == 'win32':
-                    self.obs_shm = mmap.mmap(-1, SIZE, tagname=OBS_SHM_NAME, access=mmap.ACCESS_READ)
-                else:
-                    self.obs_shm = shared_memory.SharedMemory(name=OBS_SHM_NAME)
+                self.obs_shm = mmap.mmap(-1, SIZE, tagname=OBS_SHM_NAME, access=mmap.ACCESS_READ)
+                print("mapped size:", self.obs_shm.size())
             except FileNotFoundError:
                 continue
             except ValueError:
@@ -69,24 +66,15 @@ class DrawSharedMemoryHandler:
         while continue_execution:
             try:
                 continue_execution = True if address is None else address.contents.value
-                if sys.platform == 'win32':
-                    self.obs_shm.seek(0)
-                    buf = self.obs_shm.read(SIZE)  # self.obs_shm.size())
-                else:
-                    buf = self.obs_shm.buf
+                self.obs_shm.seek(0)
+                buf = self.obs_shm.read(SIZE) #self.obs_shm.size())
                 image = read_shared_frame(buf, HEADER_SIZE, HEADER_FORMAT)
             except TypeError as e:
-                print("Type Error: ", e)
-                print("Stopping Draw2...")
-                self.obs_shm.close()
-                self.python_shm.close()
-                return
+                print("type error: ", e)
+                breakpoint()
             except ValueError as e:
-                print("Value Error: ", e)
-                print("Stopping Draw2...")
-                self.obs_shm.close()
-                self.python_shm.close()
-                return
+                print("value error: ", e)
+                breakpoint()
             except KeyboardInterrupt:
                 print("Stopping Draw2...")
                 self.obs_shm.close()
@@ -154,30 +142,19 @@ class DrawSharedMemoryHandler:
         total_size = HEADER_SIZE + len(img_bytes)
 
         if self.python_shm is None:
-            if sys.platform == 'win32':
-                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-                self.python_shm.seek(0)
-                self.python_shm.write(b"\x00" * total_size)
-            else:
-                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
+            self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
+            self.python_shm.seek(0)
+            self.python_shm.write(b"\x00" * total_size)
 
         if total_size != self.python_shm.size:
             self.python_shm.close()
-            if sys.platform == 'win32':
-                self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
-                self.python_shm.seek(0)
-                self.python_shm.write(b"\x00" * total_size)
-            else:
-                self.python_shm.unlink()
-                self.python_shm = shared_memory.SharedMemory(name=PYTHON_SHM_NAME, create=True, size=total_size)
-
-        if sys.platform == 'win32':
+            self.python_shm = mmap.mmap(-1, total_size, tagname=PYTHON_SHM_NAME, access=mmap.ACCESS_WRITE)
             self.python_shm.seek(0)
-            self.python_shm.write(struct.pack(HEADER_FORMAT, width, height))
-            self.python_shm.write(img_bytes)
-        else:
-            self.python_shm.buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
-            self.python_shm.buf[HEADER_SIZE:] = img_bytes
+            self.python_shm.write(b"\x00" * total_size)
+
+        self.python_shm.seek(0)
+        self.python_shm.write(struct.pack(HEADER_FORMAT, width, height))
+        self.python_shm.write(img_bytes)
 
         print(f"Sent image {width}x{height} to OBS")
 
@@ -215,4 +192,5 @@ def run(
 
 
 if __name__ == '__main__':
+    print("run")
     run()


### PR DESCRIPTION
This pull request refactors the shared memory handling in `src/draw/run.py` to use the `mmap` module instead of `multiprocessing.shared_memory`, and adds robust logging and print redirection for better debugging. The main themes are improved logging/debugging and a switch to a more compatible shared memory approach.

**Logging and Debugging Improvements:**

* Introduced immediate-flush logging to a file in the OBS Studio app data directory, and redirected both `stdout` and `stderr` to this log file for real-time print and error output.
* Added informative log and print statements at process start and key error handling points to aid in debugging. [[1]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cR6-R42) [[2]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL61-R95) [[3]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cR214)

**Shared Memory Refactor:**

* Replaced usage of `multiprocessing.shared_memory.SharedMemory` with `mmap.mmap` for both reading from and writing to shared memory, including proper handling of memory mapping, seeking, and writing. [[1]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL48-R79) [[2]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL133-R176)
* Updated error handling to account for possible `OSError` during memory mapping and improved buffer management for reading/writing image data. [[1]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL48-R79) [[2]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL61-R95) [[3]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL133-R176)