### PR TITLE
Refactor logging and shared memory handling for cross-platform clarity

### DIFF
--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -146,7 +146,7 @@ class DrawSharedMemoryHandler:
             python_buf = memoryview(self.python_shm)
             self.shm_array = np.ndarray((height, width, channels), dtype=np.uint8, buffer=python_buf[HEADER_SIZE:])
             python_buf[:HEADER_SIZE] = struct.pack(HEADER_FORMAT, width, height)
-        elif self.python_shm is None or total_size != self.python_shm.size:
+        elif sys.platform != 'win32' and (self.python_shm is None or total_size != self.python_shm.size):
             if self.python_shm is not None:
                 self.python_shm.close()
                 self.python_shm.unlink()

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -6,8 +6,8 @@ from multiprocessing import shared_memory
 import mmap
 
 import numpy as np
-from .draw import Draw
-from .utils import read_shared_frame, get_deck_list
+from draw.draw import Draw
+from draw.utils import read_shared_frame, get_deck_list
 
 import os
 import sys

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -13,6 +13,28 @@ import os
 import sys
 import logging
 
+if sys.platform == 'win32':
+    log_dir = os.path.join(os.environ["APPDATA"], "obs-studio")
+    os.makedirs(log_dir, exist_ok=True)
+
+    log_path = os.path.join(log_dir, "python_subprocess.log")
+
+    # --- logging (flushes immediately) ---
+    logging.basicConfig(
+        filename=log_path,
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        force=True,  # important if logging was configured before
+    )
+
+    # --- redirect print() too ---
+    log_file = open(log_path, "a", buffering=1)  # line-buffered
+    sys.stdout = log_file
+    sys.stderr = log_file
+
+    logging.info("Python subprocess started")
+    print("print() is real-time now")
+
 OBS_SHM_NAME = "obs_shared_memory"
 PYTHON_SHM_NAME = "python_shared_memory"
 HEADER_FORMAT = "II"
@@ -200,27 +222,4 @@ def run(
 
 
 if __name__ == '__main__':
-    if sys.platform == 'win32':
-        log_dir = os.path.join(os.environ["APPDATA"], "obs-studio")
-        os.makedirs(log_dir, exist_ok=True)
-
-        log_path = os.path.join(log_dir, "python_subprocess.log")
-
-        # --- logging (flushes immediately) ---
-        logging.basicConfig(
-            filename=log_path,
-            level=logging.DEBUG,
-            format="%(asctime)s [%(levelname)s] %(message)s",
-            force=True,  # important if logging was configured before
-        )
-
-        # --- redirect print() too ---
-        log_file = open(log_path, "a", buffering=1)  # line-buffered
-        sys.stdout = log_file
-        sys.stderr = log_file
-
-        logging.info("Python subprocess started")
-        print("print() is real-time now")
-    sys.stderr = sys.stdout
-    print("run")
     run()

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -4,8 +4,8 @@ import time
 from collections import deque
 from multiprocessing import shared_memory
 import mmap
-
 import numpy as np
+
 from draw.draw import Draw
 from draw.utils import read_shared_frame, get_deck_list
 
@@ -33,7 +33,6 @@ if sys.platform == 'win32':
     sys.stderr = log_file
 
     logging.info("Python subprocess started")
-    print("print() is real-time now")
 
 OBS_SHM_NAME = "obs_shared_memory"
 PYTHON_SHM_NAME = "python_shared_memory"
@@ -42,7 +41,7 @@ HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
 
 MAX_FRAME_WIDTH = 3840
 MAX_FRAME_HEIGHT = 2160
-BYTES_PER_PIXEL = 4  # RGBA8
+BYTES_PER_PIXEL = 4
 FRAME_BUFFER_SIZE = MAX_FRAME_WIDTH * MAX_FRAME_HEIGHT * BYTES_PER_PIXEL
 
 SIZE = HEADER_SIZE + FRAME_BUFFER_SIZE
@@ -154,7 +153,6 @@ class DrawSharedMemoryHandler:
 
     def send_image_to_obs(self, image):
         img_array = np.array(image.convert("RGBA"))
-        print(image.size)
         height, width, channels = img_array.shape
 
         total_size = HEADER_SIZE + img_array.nbytes


### PR DESCRIPTION
This pull request introduces improved Windows-specific logging and output redirection for the `src/draw/run.py` script, along with minor code cleanup and platform-specific shared memory handling. The main changes focus on initializing logging earlier, ensuring all output (including print statements) is captured in a log file on Windows, and simplifying the script's entrypoint.

Windows-specific logging and output redirection:

* Moved Windows logging and output redirection setup from the script entrypoint to the module level, ensuring logging is initialized before any other code runs and that all print statements and errors are redirected to the log file (`python_subprocess.log`).
* Removed duplicate logging and print redirection code from the `__main__` block, streamlining script startup.

Platform-specific shared memory handling:

* Updated the shared memory allocation logic in `send_image_to_obs` to only reallocate memory on non-Windows platforms, preventing unnecessary operations on Windows.

Code cleanup:

* Removed a debug print statement from the `send_image_to_obs` method for cleaner output.

Imports organization:

* Changed relative imports to absolute imports for `Draw`, `read_shared_frame`, and `get_deck_list` to improve clarity and maintainability.