### PR TITLE
fix: update model_size parameter to accept integer index for selection

### DIFF
--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -193,12 +193,13 @@ def run(
         stop_flag=None,
         model_ready=None,
         update_flag=None,
-        model_size="Base",
+        model_size=0,
         deck_list="",
         minimum_out_of_screen_time=25,
         minimum_screen_time=6,
         confidence_threshold=5
 ):
+    print(model_size)
     print("Starting Draw2...")
     if stop_flag is not None and model_ready is not None and update_flag is not None:
         addr = ctypes.cast(ctypes.pythonapi.PyCapsule_GetPointer(stop_flag, b"stop_flag"),
@@ -210,7 +211,7 @@ def run(
 
         update_ptr.contents.value = True
         sh_memory_handler = DrawSharedMemoryHandler(
-            model_id={"Base": "HichTala/draw2", "Large": "HichTala/draw2-large"}[model_size],
+            model_id=["HichTala/draw2", "HichTala/draw2-large"][model_size],
             deck_list=deck_list,
             minimum_out_of_screen_time=minimum_out_of_screen_time,
             minimum_screen_time=minimum_screen_time,


### PR DESCRIPTION
This pull request updates how the `model_size` parameter is handled in the `run` function in `src/draw/run.py`. The main change is switching from a string-based to an integer-based approach for selecting the model, which simplifies the code and reduces potential errors.

Parameter handling improvements:

* Changed the default value of the `model_size` parameter in the `run` function from the string `"Base"` to the integer `0`, and updated its usage to select the model by index instead of by key. [[1]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL196-R202) [[2]](diffhunk://#diff-e1cd77aabe453c2da8813ebe781b1102242072316387e6b859a4615f7e6ac84cL213-R214)

Debugging/logging:

* Added a print statement to output the value of `model_size` at the start of the `run` function for debugging purposes.