### PR TITLE
fix: log file mode to overwrite and clean up print statements

### DIFF
--- a/src/draw/draw.py
+++ b/src/draw/draw.py
@@ -60,7 +60,6 @@ class Draw:
             boxe = np.float32(
                 [[b[0] * result.orig_img.shape[1], b[1] * result.orig_img.shape[0]] for b in boxe.cpu()]
             )
-            obb = np.intp(boxe)
 
             output_pts = np.float32([
                 [224, 224],

--- a/src/draw/run.py
+++ b/src/draw/run.py
@@ -28,7 +28,7 @@ if sys.platform == 'win32':
     )
 
     # --- redirect print() too ---
-    log_file = open(log_path, "a", buffering=1)  # line-buffered
+    log_file = open(log_path, "w", buffering=1)  # line-buffered
     sys.stdout = log_file
     sys.stderr = log_file
 
@@ -199,7 +199,6 @@ def run(
         minimum_screen_time=6,
         confidence_threshold=5
 ):
-    print(model_size)
     print("Starting Draw2...")
     if stop_flag is not None and model_ready is not None and update_flag is not None:
         addr = ctypes.cast(ctypes.pythonapi.PyCapsule_GetPointer(stop_flag, b"stop_flag"),


### PR DESCRIPTION
This pull request includes a few small changes to the logging and output handling in the drawing pipeline. The most notable changes are switching log file writes to overwrite mode and removing an unnecessary print statement.

- Logging improvements:
  * Changed the log file in `src/draw/run.py` to open in write mode (`"w"`) instead of append mode (`"a"`), ensuring each run starts with a fresh log.
  * Removed an extraneous print statement for `model_size` in the `run` function of `src/draw/run.py` to reduce console clutter.

- Code cleanup:
  * Removed an unused variable assignment (`obb = np.intp(boxe)`) in `src/draw/draw.py` to clean up the code.…tatement