### PR TITLE
feat: disable progress bars for dataset loading and transformers in d…

### DIFF
--- a/src/draw/draw.py
+++ b/src/draw/draw.py
@@ -11,6 +11,16 @@ from huggingface_hub import hf_hub_download
 if sys.platform == 'win32':
     os.add_dll_directory(sys.prefix)
 
+    from datasets import disable_progress_bar as disable_dataset_progress_bar, \
+        disable_progress_bars as disable_dataset_progress_bars
+    from transformers.utils.logging import disable_progress_bar as disable_transformers_progress_bar
+    from huggingface_hub.utils import disable_progress_bars
+
+    disable_dataset_progress_bar()
+    disable_dataset_progress_bars()
+    disable_transformers_progress_bar()
+    disable_progress_bars()
+
 import cv2
 from transformers import AutoImageProcessor, pipeline
 from ultralytics import YOLO


### PR DESCRIPTION
This pull request adds code to suppress progress bars from several popular machine learning libraries when running on Windows. This helps keep the console output clean, uncluttered during execution and avoiding some char code character errors.

Progress bar suppression:

* Imports and calls functions to disable progress bars from the `datasets`, `transformers`, and `huggingface_hub` libraries when running on Windows in `src/draw/draw.py`.…raw.py